### PR TITLE
build(deps): require Node 24 and pin active version to 24.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Setup Pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-eslint": "^8.61.0"
       },
       "engines": {
-        "node": ">=22.22.1"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "typescript-eslint": "^8.61.0"
   },
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=24.0.0"
   },
   "volta": {
-    "node": "22.22.2"
+    "node": "24.16.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps the project's minimum supported Node version to **24** (current LTS "Krypton") and pins the active Volta toolchain to **24.16.0**. CI now builds and runs quality checks on Node 24.

The project never had a Node-version test matrix (the existing matrix only covered `eslint`/`prettier`/`type-check`; Node was hardcoded to `22`), so this simply raises the floor rather than adding a matrix.

## Changes

| File | Change |
|------|--------|
| `package.json` | `engines.node` `>=22.22.1` → `>=24.0.0`; `volta.node` `22.22.2` → `24.16.0` |
| `package-lock.json` | Root `engines.node` synced to `>=24.0.0` |
| `.github/workflows/ci.yml` | `node-version` `22` → `24` in both `quality` and `build` jobs |

## Dependency compatibility

Scanned **all 316 dependencies** declaring `engines.node` — **none have an upper bound**, so nothing caps Node 24. Tightest floors: `lint-staged` `>=22.22.1`, `next` `>=20.9.0`, `eslint` `^18.18.0 || ^20.9.0 || >=21.1.0` — all satisfied by Node 24.

## Verification

- ✅ `npm run type-check` passes
- ✅ `npm run build` passes (all routes prerendered)

## Optional follow-up

`@types/node` is currently `^25.9.3` (Node 25 Current line), ahead of the pinned Node 24 runtime. Works fine (newer types are a superset), but pinning to `^24` would match the runtime exactly. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)